### PR TITLE
Fix Path traversal vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ const genDirHTML = (files) => {
 const server = http.createServer(async (req, res) => {
     console.log("::request::", req.url);
     req.url = querystring.unescape(req.url);
+    req.url = req.url.replace(/(\.\.\/?)/g, '');
+    console.log("::request Clean::", req.url);
     const fp = path.join(process.cwd(), req.url);
     try {
         // if a file does not exist we send a 404 from catch

--- a/index.js
+++ b/index.js
@@ -15,26 +15,30 @@ const path = require("path");
 const util = require("util");
 const mime = require("mime-types");
 const Entities = require('html-entities').AllHtmlEntities;
- 
+const querystring = require('querystring');
+
 const PORT = process.argv[2] || 8080;
 const _access = util.promisify(fs.access);
 const _readdir = util.promisify(fs.readdir);
 const entities = new Entities();
+const regJS = /javascript\s*:\s*/
 
 const genDirHTML = (files) => {
     let d_listing = "<pre>\n";
     d_listing += "<a href=\"../\">../</a>\n";
     files.forEach(file => {
+        var extraJS = regJS.exec(file.name) ? './':'';
         file.name =  entities.encode(file.name);
         file.isDir
-            ? d_listing += `<a href="${file.name}/">${file.name}/</a>\n`
-            : d_listing += `<a href="${file.name}">${file.name}</a>\n`;
+            ? d_listing += `<a href="${extraJS}${file.name}/">${file.name}/</a>\n`
+            : d_listing += `<a href="${extraJS}${file.name}">${file.name}</a>\n`;
     });
     return d_listing + "</pre>";
 };
 
 const server = http.createServer(async (req, res) => {
     console.log("::request::", req.url);
+    req.url = querystring.unescape(req.url);
     const fp = path.join(process.cwd(), req.url);
     try {
         // if a file does not exist we send a 404 from catch

--- a/index.js
+++ b/index.js
@@ -14,15 +14,18 @@ const fs = require("fs");
 const path = require("path");
 const util = require("util");
 const mime = require("mime-types");
-
+const Entities = require('html-entities').AllHtmlEntities;
+ 
 const PORT = process.argv[2] || 8080;
 const _access = util.promisify(fs.access);
 const _readdir = util.promisify(fs.readdir);
+const entities = new Entities();
 
 const genDirHTML = (files) => {
     let d_listing = "<pre>\n";
     d_listing += "<a href=\"../\">../</a>\n";
     files.forEach(file => {
+        file.name =  entities.encode(file.name);
         file.isDir
             ? d_listing += `<a href="${file.name}/">${file.name}/</a>\n`
             : d_listing += `<a href="${file.name}">${file.name}</a>\n`;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/lap00zza/Snek-Serve#readme",
   "dependencies": {
+    "html-entities": "^1.3.1",
     "mime-types": "^2.1.20"
   }
 }


### PR DESCRIPTION

The `snekserve` is vulnerable against Directory Traversal, which may allow access to sensitive files and data on the server.
For example, requesting the following URL: `/../../etc/passwd` would result in `/etc/passwd` leaking.

### ⚙️ Description *

There is no path sanitization in the path provided making marscode vulnerable against path traversal through the ../ technique, leading to information exposure and file content disclosure.

### 💻 Technical Description *

Fixed by sanitizing any occurrence of ../, using regexp.

### 🐛 Proof of Concept (PoC) *

1. Start the server
`node index.js`
2. Request private file from server
`curl -v --path-as-is http://127.0.0.1:8080/../../../../../../../../../../../etc/passwd`
3. /etc/passwd will be displayed.

![SnekServPOC](https://user-images.githubusercontent.com/7505980/95334571-fa385d00-08b6-11eb-9cc6-5317489271f9.png)

### Proof of Fix (PoF) *

After fix Response code 400 Bad request is returned to user instead of restricted file conten

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected